### PR TITLE
fix: added closeSerial to sample.

### DIFF
--- a/samples/sample.html
+++ b/samples/sample.html
@@ -30,6 +30,7 @@
           if (success) {
             console.log('.hex file uploaded on board successfully!');
           }
+          avrbro.closeSerial(serial);
         } else {
           console.log('Operation canceled by user');
         }


### PR DESCRIPTION
Perfect library my friend. 

Added closeSerial() to sample file, as it doesn't close the port after flashing and the device becomes unusable, until unplugged.